### PR TITLE
Prueba del servicio de vuelos al retornar una lista vacia

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,12 @@
 			<artifactId>modelmapper</artifactId>
 			<version>3.1.0</version>
 		</dependency>
+		
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/CaC/Grupo2/FlySky/dto/AsientoDto.java
+++ b/src/main/java/CaC/Grupo2/FlySky/dto/AsientoDto.java
@@ -1,9 +1,19 @@
 package CaC.Grupo2.FlySky.dto;
 
+import CaC.Grupo2.FlySky.entity.Asiento;
+
 import javax.persistence.Column;
 
 public class AsientoDto {
-    UsuarioDto usuarioDto;
+    String pasajero;
     private boolean ocupado;
     private String ubicacion;
+    
+    public static AsientoDto of(Asiento e) {
+        AsientoDto dto  = new AsientoDto();
+        dto.pasajero    = e.getNombreCompletoUsuario();
+        dto.ubicacion   = e.getUbicacion();
+        dto.ocupado     = e.isOcupado();
+        return dto;
+    }
 }

--- a/src/main/java/CaC/Grupo2/FlySky/dto/VueloDto.java
+++ b/src/main/java/CaC/Grupo2/FlySky/dto/VueloDto.java
@@ -2,12 +2,14 @@ package CaC.Grupo2.FlySky.dto;
 
 import CaC.Grupo2.FlySky.entity.Asiento;
 import CaC.Grupo2.FlySky.entity.Reserva;
+import CaC.Grupo2.FlySky.entity.Vuelo;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.OneToMany;
 import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class VueloDto {
     private List<AsientoDto> asientos;
@@ -17,4 +19,18 @@ public class VueloDto {
     private int precio;
     private boolean conexion;
     private String aerolinea;
+   
+   public static VueloDto of(Vuelo e) {
+      VueloDto dto = new VueloDto();
+      dto.aerolinea     = e.getAerolinea();
+      dto.asientos      = e.getAsientos()
+              .stream().map(AsientoDto::of)
+              .collect(Collectors.toList());
+      dto.conexion      = e.isConexion();
+      dto.destino       = e.getDestino();
+      dto.origen        = e.getOrigen();
+      dto.fecha         = e.getFecha();
+      dto.precio        = e.getPrecio();
+      return dto;
+   }
 }

--- a/src/main/java/CaC/Grupo2/FlySky/entity/Asiento.java
+++ b/src/main/java/CaC/Grupo2/FlySky/entity/Asiento.java
@@ -1,9 +1,12 @@
 package CaC.Grupo2.FlySky.entity;
 
+import lombok.Data;
+
 import javax.persistence.*;
 
 @Entity
 @Table(name = "asiento")
+@Data
 public class Asiento {
 
     @Id

--- a/src/main/java/CaC/Grupo2/FlySky/entity/Vuelo.java
+++ b/src/main/java/CaC/Grupo2/FlySky/entity/Vuelo.java
@@ -1,11 +1,14 @@
 package CaC.Grupo2.FlySky.entity;
 
+import lombok.Data;
+
 import javax.persistence.*;
 import java.util.Date;
 import java.util.List;
 
 @Entity
 @Table(name = "vuelo")
+@Data
 public class Vuelo {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/CaC/Grupo2/FlySky/repositories/IFlyRepository.java
+++ b/src/main/java/CaC/Grupo2/FlySky/repositories/IFlyRepository.java
@@ -1,0 +1,9 @@
+package CaC.Grupo2.FlySky.repositories;
+
+import CaC.Grupo2.FlySky.entity.Vuelo;
+
+import java.util.List;
+
+public interface IFlyRepository {
+   List<Vuelo> buscarVuelos();
+}

--- a/src/main/java/CaC/Grupo2/FlySky/service/FlyService.java
+++ b/src/main/java/CaC/Grupo2/FlySky/service/FlyService.java
@@ -2,19 +2,30 @@ package CaC.Grupo2.FlySky.service;
 
 import CaC.Grupo2.FlySky.dto.ReservaDto;
 import CaC.Grupo2.FlySky.dto.VueloDto;
+import CaC.Grupo2.FlySky.entity.Vuelo;
+import CaC.Grupo2.FlySky.repositories.IFlyRepository;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Qualifier("flyService")
 public class FlyService implements IFlyService{
-
-
+    
+    
+    private final IFlyRepository repository;
+    
+    public FlyService(IFlyRepository repo) {
+        this.repository = repo;
+    }
+    
     @Override
     public List<VueloDto> buscarTodosVuelos() {
-        return null;
+        List<Vuelo> vuelos = repository.buscarVuelos();
+        return vuelos.stream().map(VueloDto::of)
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/src/test/java/CaC/Grupo2/FlySky/service/flyservice/FlyServiceRetornandoLosVuelos.java
+++ b/src/test/java/CaC/Grupo2/FlySky/service/flyservice/FlyServiceRetornandoLosVuelos.java
@@ -1,0 +1,31 @@
+package CaC.Grupo2.FlySky.service.flyservice;
+
+import CaC.Grupo2.FlySky.dto.VueloDto;
+import CaC.Grupo2.FlySky.entity.Vuelo;
+import CaC.Grupo2.FlySky.repositories.IFlyRepository;
+import CaC.Grupo2.FlySky.service.FlyService;
+import org.junit.jupiter.api.Test;
+import org.mockito.stubbing.OngoingStubbing;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FlyServiceRetornandoLosVuelos {
+   
+   @Test void
+   cuando_la_BD_esta_vacia__debe_retornar_una_lista_vacia_de_DTO(){
+      IFlyRepository repo = mock(IFlyRepository.class);
+      when(repo.buscarVuelos()).thenReturn(new ArrayList<Vuelo>());
+      FlyService fly_service = new FlyService(repo);
+      
+      List<VueloDto> flies = fly_service.buscarTodosVuelos();
+      
+      assertThat( flies, is(empty()) );
+   }
+}


### PR DESCRIPTION
Se realizó la prueba unitaria para el servicio de vuelos al tener un repositorio vació.
Se modificaron 8 ficheros:

- AsientoDto. Se le agregó una función estática para construir desde una Entidad Asiento.
 También se modificó el atributo "usuario" por "pasajero", ya que el pasajero es el que ocupa el asiento y el usuario es el que realiza la reserva.

- VueloDto. Se agregó una función estática para construirse desde la entidad Vuelo.

- Asiento. Se agregó el decorador @Data para dar acceso a las funciones miembro de la clase.

- Vuelo. Se agregó el decorador   @Data para dar acceso a las funciones miembro de la clase.

- IFlyRepository. Es la interfáz para el repositorio de Vuelos.

- FlyService. Se implemetó la función buscarTodosVuelos(), Hace la captura de los vuelos desde el repositorio.

- pom.xml. Se agregó la dependencia a Hamcrest para las pruebas unitarias.

- Se creo la clase que ejecuta la prueba. "FlyServiceRetornandoLosVuelos"